### PR TITLE
Removed SimpleTimer.h library

### DIFF
--- a/Tracer-RS485-Modbus-Blynk-V2.ino
+++ b/Tracer-RS485-Modbus-Blynk-V2.ino
@@ -22,7 +22,6 @@
 #include <WiFiUdp.h>
 #include <ArduinoOTA.h>
 #include <BlynkSimpleEsp8266.h>
-#include <SimpleTimer.h>
 #include <ModbusMaster.h>
 #include "settings.h"
 


### PR DESCRIPTION
Definition of SimpleTimer is now defined as part of BlinkTimer class in the Blynk libraries
![image](https://user-images.githubusercontent.com/1219903/103383829-1af60480-4aec-11eb-90f1-c07e4f202292.png)
